### PR TITLE
fix(ux): remove conteúdo fabricado nas Fases 2 e 3

### DIFF
--- a/src/components/pdi/PdiScreen.tsx
+++ b/src/components/pdi/PdiScreen.tsx
@@ -274,36 +274,28 @@ function workspaceForScreen(
         <header className="workspace-header">
           <div className="workspace-breadcrumb">Fase 2 · Diagnóstico Adaptativo</div>
           <h1 className="workspace-title">Classificação do ramo e perguntas dinâmicas</h1>
-          <p className="workspace-subtitle">A conversa muda conforme suas respostas e confirmações de gate.</p>
+          <p className="workspace-subtitle">O mentor analisa seu obstáculo e aprofunda com perguntas específicas do padrão identificado.</p>
         </header>
         <section className="workspace-body">
           {phase2StructuredOutput ? (
             <article className="card">
               <div className="card-header">
-                <h2 className="card-title">Resumo Executivo Atual</h2>
+                <h2 className="card-title">Diagnóstico adaptativo consolidado</h2>
               </div>
               <div className="card-body">
                 <MarkdownContent content={phase2StructuredOutput} />
               </div>
             </article>
-          ) : null}
-          <article className="card">
-            <div className="card-header"><h2 className="card-title">Ramos de diagnóstico</h2></div>
-            <div className="card-body">
-              <div className="table-wrap">
-                <table className="data-table" style={{ minWidth: 740 }}>
-                  <thead><tr><th>Ramo</th><th>Descrição</th><th>Status</th></tr></thead>
-                  <tbody>
-                    <tr><td>A</td><td>Gap de competência</td><td><span className="badge warning">Em análise</span></td></tr>
-                    <tr><td>B</td><td>Gap de visibilidade</td><td><span className="badge info">Possível</span></td></tr>
-                    <tr><td>C</td><td>Transição de mercado</td><td><span className="badge info">Possível</span></td></tr>
-                    <tr><td>D</td><td>Clareza de direção</td><td><span className="badge info">Possível</span></td></tr>
-                    <tr><td>E</td><td>Restrição operacional</td><td><span className="badge info">Possível</span></td></tr>
-                  </tbody>
-                </table>
+          ) : (
+            <article className="card">
+              <div className="card-header"><h2 className="card-title">Em andamento</h2></div>
+              <div className="card-body">
+                <div className="callout info">
+                  O mentor está identificando o padrão do seu obstáculo e conduzindo as perguntas específicas no chat. O diagnóstico consolidado aparecerá aqui ao final desta fase.
+                </div>
               </div>
-            </div>
-          </article>
+            </article>
+          )}
         </section>
       </>
     )
@@ -315,30 +307,28 @@ function workspaceForScreen(
         <header className="workspace-header">
           <div className="workspace-breadcrumb">Fase 3 · Hipótese de Direção</div>
           <h1 className="workspace-title">Síntese estratégica e escolha de caminho</h1>
-          <p className="workspace-subtitle">Entrega de síntese, caminhos possíveis e recomendação fundamentada.</p>
+          <p className="workspace-subtitle">O mentor sintetiza o diagnóstico, mapeia caminhos possíveis e apresenta uma recomendação fundamentada.</p>
         </header>
         <section className="workspace-body">
           {phase3StructuredOutput ? (
             <article className="card">
               <div className="card-header">
-                <h2 className="card-title">Direção Estratégica Atual</h2>
+                <h2 className="card-title">Direção estratégica</h2>
               </div>
               <div className="card-body">
                 <MarkdownContent content={phase3StructuredOutput} />
               </div>
             </article>
-          ) : null}
-          <article className="card">
-            <div className="card-header"><h2 className="card-title">Caminhos possíveis</h2></div>
-            <div className="card-body">
-              <div className="kv-grid">
-                <div><div className="kv-label">Caminho A</div><div className="kv-value">Aceleração interna por visibilidade de impacto.</div></div>
-                <div><div className="kv-label">Caminho B</div><div className="kv-value">Posicionamento híbrido com opcionalidade externa.</div></div>
-                <div><div className="kv-label">Caminho C</div><div className="kv-value">Transição estruturada de mercado com runway controlado.</div></div>
-                <div><div className="kv-label">Recomendação</div><div className="kv-value">B, por balancear risco e velocidade de progressão.</div></div>
+          ) : (
+            <article className="card">
+              <div className="card-header"><h2 className="card-title">Em andamento</h2></div>
+              <div className="card-body">
+                <div className="callout info">
+                  O mentor está elaborando a síntese do seu diagnóstico e os caminhos possíveis. A direção estratégica recomendada aparecerá aqui para você confirmar ou ajustar via chat.
+                </div>
               </div>
-            </div>
-          </article>
+            </article>
+          )}
         </section>
       </>
     )

--- a/src/lib/pdi/chat-engine.ts
+++ b/src/lib/pdi/chat-engine.ts
@@ -1,0 +1,123 @@
+import type { ConversationPhase, Message } from '@prisma/client'
+import { chatWithAI } from '@/lib/ai/client'
+import { buildPdiChatSystemPrompt } from './prompts'
+import { isStructuredPhaseOutput } from './structured-output'
+
+export function getPhase1AnchorQuestionsMessage(): string {
+  return PHASE1_ANCHOR_QUESTIONS[0]
+}
+
+export function getPhase2BranchGateQuestionMessage(): string {
+  return PHASE2_BRANCH_GATE_QUESTION
+}
+
+const PHASE1_ANCHOR_QUESTIONS = [
+  '1. Onde você está hoje? (cargo, senioridade, empresa/setor, regime de trabalho)',
+  '2. Qual resultado concreto você quer em 12 meses? (cargo, impacto e faixa salarial)',
+  '3. Na sua visão, qual é o maior obstáculo entre o estado atual e o objetivo?',
+  '4. Qual sua formação acadêmica atual? (curso, nível e status)',
+] as const
+
+const PHASE2_BRANCH_GATE_QUESTION =
+  'Agora vou aprofundar o diagnóstico. Me conta: no seu dia a dia, como esse obstáculo aparece concretamente? Pode ser uma situação recente, um padrão que se repete ou uma tensão que você sente com frequência.'
+
+const FALLBACK_BY_PHASE: Record<ConversationPhase, string> = {
+  PHASE_1_DIAGNOSTICO:
+    'Não consegui concluir o diagnóstico âncora agora. Reenvie suas respostas para eu identificar o obstáculo principal e seguir para a Fase 2.',
+  PHASE_2_ADAPTATIVO:
+    'Não consegui concluir o diagnóstico adaptativo agora. Reenvie sua última resposta para eu classificar o ramo e fechar ✅ Confirmado / ⚠️ Falta.',
+  PHASE_3_DIRECAO:
+    'Não consegui concluir a hipótese de direção agora. Reenvie para eu retornar os caminhos e recomendação.',
+  PHASE_5_FINAL:
+    'Não consegui atualizar os entregáveis finais agora. Reenvie o ajuste desejado para eu recalibrar o documento.',
+  PHASE_REVISAO:
+    'Não consegui processar a revisão agora. Reenvie a alteração solicitada para gerar nova versão.',
+}
+
+function toAIMessage(
+  history: Message[]
+): Array<{ role: 'user' | 'assistant'; content: string }> {
+  return history
+    .filter((message) => message.role === 'USER' || message.role === 'ASSISTANT')
+    .map((message) => ({
+      role: message.role === 'USER' ? 'user' : 'assistant',
+      content: message.content,
+    }))
+}
+
+function countUserMessages(history: Message[]): number {
+  return history.filter((message) => message.role === 'USER').length
+}
+
+function normalizePhase2SingleQuestion(content: string): string {
+  const text = content.trim()
+  if (!text) return text
+  if (isStructuredPhaseOutput(text)) return text
+
+  const questionMatches = text
+    .split(/\n+/)
+    .flatMap((line) => line.match(/[^?]*\?/g) ?? [])
+    .map((item) => item.replace(/\s+/g, ' ').trim())
+    .filter((item) => item.length > 0)
+
+  if (questionMatches.length <= 1) {
+    return text
+  }
+
+  const firstQuestion = questionMatches[0]
+  const firstQuestionIndex = text.indexOf(firstQuestion)
+  if (firstQuestionIndex < 0) {
+    return firstQuestion
+  }
+
+  const intro = text.slice(0, firstQuestionIndex).trim()
+  if (!intro) {
+    return firstQuestion
+  }
+
+  return `${intro}\n\n${firstQuestion}`
+}
+
+export async function buildAssistantReply(
+  phase: ConversationPhase,
+  userMessage: string,
+  history: Message[]
+) {
+  if (phase === 'PHASE_1_DIAGNOSTICO') {
+    const userCount = countUserMessages(history)
+    const nextIndex = Math.min(
+      userCount,
+      PHASE1_ANCHOR_QUESTIONS.length - 1
+    )
+
+    if (userCount < PHASE1_ANCHOR_QUESTIONS.length) {
+      return PHASE1_ANCHOR_QUESTIONS[nextIndex]
+    }
+  }
+
+  try {
+    const aiMessages = toAIMessage(history)
+    if (aiMessages.length === 0) {
+      aiMessages.push({ role: 'user', content: userMessage })
+    }
+
+    const response = await chatWithAI({
+      phase: 'pdi_chat',
+      systemPrompt: buildPdiChatSystemPrompt(phase),
+      messages: aiMessages,
+    })
+
+    const text = response.text.trim()
+    if (!text) {
+      return FALLBACK_BY_PHASE[phase]
+    }
+
+    if (phase === 'PHASE_2_ADAPTATIVO') {
+      return normalizePhase2SingleQuestion(text)
+    }
+
+    return text
+  } catch {
+    return FALLBACK_BY_PHASE[phase]
+  }
+}


### PR DESCRIPTION
## Summary

- **Fase 2 — workspace**: tabela de ramos com status hardcoded (`Em análise`, `Possível`) removida — os valores eram fixos e não refletiam nenhum estado real. Substituída por callout neutro enquanto o diagnóstico não chega; quando o output estruturado do AI chegar, exibe o card real.
- **Fase 3 — workspace**: kv-grid com caminhos A/B/C e recomendação completamente inventados (`Aceleração interna por visibilidade`, `Posicionamento híbrido`, `Recomendação: B`) removidos — eram desvinculados de qualquer dado do usuário e induziam erro. Mesmo padrão de espera neutro.
- **Fase 2 — chat gate**: pergunta reescrita de autodiagnóstico (`qual ramo descreve seu obstáculo: A, B, C, D ou E?`) para pergunta aberta (`me conta como esse obstáculo aparece no dia a dia`) — o AI classifica o padrão internamente, sem transferir essa responsabilidade para o usuário.

## Test plan

- [ ] Fase 2: workspace mostra callout neutro antes de qualquer output estruturado
- [ ] Fase 2: workspace exibe o card com conteúdo real após o AI retornar output estruturado
- [ ] Fase 2: primeira mensagem do chat é a nova pergunta aberta (não a lista A/B/C/D/E)
- [ ] Fase 3: workspace mostra callout neutro antes de qualquer output estruturado
- [ ] Fase 3: workspace exibe o card com a direção estratégica após o AI retornar output estruturado

🤖 Generated with [Claude Code](https://claude.com/claude-code)