### PR TITLE
feat(personas): sistema de personas — Mentoria de Carreira e PDI Expresso

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,221 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider  = "postgresql"
+  url       = env("DATABASE_URL")
+  directUrl = env("DATABASE_URL_UNPOOLED")
+}
+
+model User {
+  id        String   @id @default(cuid())
+  clerkId   String   @unique
+  email     String   @unique
+  name      String?
+  avatarUrl String?
+
+  projects Project[]
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@map("users")
+}
+
+model Project {
+  id          String        @id
+  userId      String
+  user        User          @relation(fields: [userId], references: [id], onDelete: Cascade)
+  name        String
+  description String?
+  status      ProjectStatus @default(DIAGNOSTICO)
+
+  currentPhase  ProjectPhase @default(PHASE_1_DIAGNOSTICO)
+  currentScreen String       @default("phase-1-diagnostico")
+  personaId     String       @default("mentoria-carreira")
+
+  conversations  Conversation[]
+  documents      PdiDocument[]
+  generationRuns PdiGenerationRun[]
+  revisions      PdiRevision[]
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([userId])
+  @@index([status])
+  @@index([currentPhase])
+  @@map("projects")
+}
+
+enum ProjectStatus {
+  DIAGNOSTICO
+  DIRECAO
+  GERANDO_PDI
+  PDI_CONCLUIDO
+  PDI_FALHOU
+}
+
+enum ProjectPhase {
+  PHASE_1_DIAGNOSTICO
+  PHASE_2_ADAPTATIVO
+  PHASE_3_DIRECAO
+  PHASE_4_PDI
+  PHASE_5_FINAL
+  PHASE_REVISAO
+}
+
+model Conversation {
+  id        String            @id @default(cuid())
+  projectId String
+  project   Project           @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  phase     ConversationPhase
+  status    ConversationStatus @default(ACTIVE)
+
+  messages Message[]
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@unique([projectId, phase])
+  @@index([projectId, status])
+  @@map("conversations")
+}
+
+enum ConversationPhase {
+  PHASE_1_DIAGNOSTICO
+  PHASE_2_ADAPTATIVO
+  PHASE_3_DIRECAO
+  PHASE_5_FINAL
+  PHASE_REVISAO
+}
+
+enum ConversationStatus {
+  ACTIVE
+  COMPLETED
+  ABANDONED
+}
+
+model Message {
+  id             String       @id @default(cuid())
+  conversationId String
+  conversation   Conversation @relation(fields: [conversationId], references: [id], onDelete: Cascade)
+
+  role    MessageRole
+  content String      @db.Text
+
+  createdAt DateTime @default(now())
+
+  @@index([conversationId, createdAt])
+  @@map("messages")
+}
+
+enum MessageRole {
+  USER
+  ASSISTANT
+  SYSTEM
+}
+
+model PdiDocument {
+  id        String            @id @default(cuid())
+  projectId String
+  project   Project           @relation(fields: [projectId], references: [id], onDelete: Cascade)
+
+  version        Int
+  status         PdiDocumentStatus @default(IN_PROGRESS)
+  fullContent    String?           @db.Text
+  summaryContent String?           @db.Text
+
+  sections       PdiDocumentSection[]
+  runs           PdiGenerationRun[]
+  revisionsFrom  PdiRevision[]      @relation("RevisionFrom")
+  revisionsTo    PdiRevision[]      @relation("RevisionTo")
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@unique([projectId, version])
+  @@index([projectId, status])
+  @@map("pdi_documents")
+}
+
+enum PdiDocumentStatus {
+  IN_PROGRESS
+  COMPLETED
+  FAILED
+}
+
+model PdiDocumentSection {
+  id         String           @id @default(cuid())
+  documentId String
+  document   PdiDocument      @relation(fields: [documentId], references: [id], onDelete: Cascade)
+
+  sectionKey   String
+  status       PdiSectionStatus @default(PENDING)
+  content      String?          @db.Text
+  errorMessage String?          @db.Text
+  generatedAt  DateTime?
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@unique([documentId, sectionKey])
+  @@index([documentId, status])
+  @@map("pdi_document_sections")
+}
+
+enum PdiSectionStatus {
+  PENDING
+  PROCESSING
+  COMPLETED
+  FAILED
+}
+
+model PdiGenerationRun {
+  id         String              @id @default(cuid())
+  projectId  String
+  project    Project             @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  documentId String
+  document   PdiDocument         @relation(fields: [documentId], references: [id], onDelete: Cascade)
+
+  status         PdiGenerationRunStatus @default(RUNNING)
+  currentSection String?
+  errorSummary   String?                @db.Text
+
+  startedAt  DateTime @default(now())
+  finishedAt DateTime?
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @updatedAt
+
+  @@index([projectId, status])
+  @@index([documentId])
+  @@map("pdi_generation_runs")
+}
+
+enum PdiGenerationRunStatus {
+  RUNNING
+  COMPLETED
+  FAILED
+}
+
+model PdiRevision {
+  id             String      @id @default(cuid())
+  projectId      String
+  project        Project     @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  fromDocumentId String
+  fromDocument   PdiDocument @relation("RevisionFrom", fields: [fromDocumentId], references: [id], onDelete: Cascade)
+  toDocumentId   String
+  toDocument     PdiDocument @relation("RevisionTo", fields: [toDocumentId], references: [id], onDelete: Cascade)
+
+  requestText String @db.Text
+  summary     String @db.Text
+  diffJson    Json
+
+  createdAt DateTime @default(now())
+
+  @@index([projectId, createdAt])
+  @@index([fromDocumentId])
+  @@index([toDocumentId])
+  @@map("pdi_revisions")
+}

--- a/src/app/api/pdi/[pdiId]/chat/route.ts
+++ b/src/app/api/pdi/[pdiId]/chat/route.ts
@@ -8,7 +8,8 @@ import {
 } from '@/lib/pdi/chat-engine'
 import { getOrCreateUserByClerkId, requireClerkUserId, UnauthorizedError } from '@/lib/auth/session'
 import { ensurePdiForUser, PdiNotFoundError } from '@/lib/pdi/access'
-import { getPersonaById } from '@/lib/pdi/personas'
+import { getPersonaById, PDI_EXPRESSO_PERSONA } from '@/lib/pdi/personas'
+import { isStructuredPhaseOutput } from '@/lib/pdi/structured-output'
 
 const chatRequestSchema = z.object({
   phase: z.enum([
@@ -27,8 +28,6 @@ const PHASE_4_SCREEN = 'phase-4-pdi/inicio'
 
 // Padrão: AI pede para avançar para Fase 2 (Mentoria de Carreira)
 const ASK_TO_ADVANCE_PHASE_2_PATTERN = /posso\s+avan[çc]ar\s+para\s+a\s+fase\s*2/i
-// Padrão: AI pede para avançar para Proposta de PDI (PDI Expresso)
-const ASK_TO_ADVANCE_DIRECT_PATTERN = /posso\s+avan[çc]ar\s+para\s+a\s+proposta\s+de\s+pdi/i
 
 const PHASE_2_CLOSING_PATTERN = /✅\s*confirmado|diagn[oó]stico adaptativo conclu[íi]do/i
 const ASK_ABOUT_PATH_PATTERN =
@@ -68,6 +67,8 @@ function shouldAdvanceToPhase2(
 }
 
 // PDI Expresso: Fase 1 → Fase 3 diretamente (pula Fase 2)
+// Usa isStructuredPhaseOutput (igual ao Mentoria de Carreira) para não depender de
+// frase exata — qualquer bloco de fechamento do PDI Expresso dispara a transição.
 function shouldAdvanceDirectlyToPhase3(
   phase: z.infer<typeof chatRequestSchema>['phase'],
   userMessage: string,
@@ -76,7 +77,7 @@ function shouldAdvanceDirectlyToPhase3(
   if (phase !== 'PHASE_1_DIAGNOSTICO') return false
   if (!isAffirmativeForPhaseAdvance(userMessage)) return false
   const latestAssistant = findLatestAssistantBeforeCurrentUser(history)
-  return ASK_TO_ADVANCE_DIRECT_PATTERN.test(latestAssistant)
+  return isStructuredPhaseOutput(latestAssistant, PDI_EXPRESSO_PERSONA.structuredOutputExtraPatterns)
 }
 
 // Mentoria de Carreira: Fase 2 → Fase 3

--- a/src/app/api/pdi/[pdiId]/chat/route.ts
+++ b/src/app/api/pdi/[pdiId]/chat/route.ts
@@ -8,6 +8,7 @@ import {
 } from '@/lib/pdi/chat-engine'
 import { getOrCreateUserByClerkId, requireClerkUserId, UnauthorizedError } from '@/lib/auth/session'
 import { ensurePdiForUser, PdiNotFoundError } from '@/lib/pdi/access'
+import { getPersonaById } from '@/lib/pdi/personas'
 
 const chatRequestSchema = z.object({
   phase: z.enum([
@@ -23,16 +24,22 @@ const chatRequestSchema = z.object({
 const PHASE_2_SCREEN = 'phase-2-adaptativo'
 const PHASE_3_SCREEN = 'phase-3-direcao'
 const PHASE_4_SCREEN = 'phase-4-pdi/inicio'
+
+// Padrão: AI pede para avançar para Fase 2 (Mentoria de Carreira)
 const ASK_TO_ADVANCE_PHASE_2_PATTERN = /posso\s+avan[çc]ar\s+para\s+a\s+fase\s*2/i
+// Padrão: AI pede para avançar para Proposta de PDI (PDI Expresso)
+const ASK_TO_ADVANCE_DIRECT_PATTERN = /posso\s+avan[çc]ar\s+para\s+a\s+proposta\s+de\s+pdi/i
+
 const PHASE_2_CLOSING_PATTERN = /✅\s*confirmado|diagn[oó]stico adaptativo conclu[íi]do/i
-const ASK_ABOUT_PATH_PATTERN = /qual\s+(desses?\s+)?caminhos?|prefere\s+seguir|quer\s+seguir|por\s+qual\s+caminho|confirmar\s+o\s+caminho/i
+const ASK_ABOUT_PATH_PATTERN =
+  /qual\s+(desses?\s+)?caminhos?|prefere\s+seguir|quer\s+seguir|por\s+qual\s+caminho|confirmar\s+o\s+caminho/i
 const NEGATIVE_INTENT_PATTERN = /\b(n[aã]o|ainda n[aã]o|espera|aguarde)\b/i
 const AFFIRMATIVE_INTENT_PATTERN =
   /\b(sim|ok|fechado|perfeito|pode|podemos|vamos|bora|seguir|siga|prosseguir|avan[çc]a|avan[çc]ar|pr[oó]xima fase|continuar|continue|confirmo|confirmado)\b/i
 
-function findLatestAssistantBeforeCurrentUser(
-  history: Array<{ role: 'USER' | 'ASSISTANT' | 'SYSTEM'; content: string }>
-): string {
+type ChatHistory = Array<{ role: 'USER' | 'ASSISTANT' | 'SYSTEM'; content: string }>
+
+function findLatestAssistantBeforeCurrentUser(history: ChatHistory): string {
   for (let index = history.length - 2; index >= 0; index -= 1) {
     const message = history[index]
     if (message.role !== 'ASSISTANT') continue
@@ -48,40 +55,52 @@ function isAffirmativeForPhaseAdvance(message: string): boolean {
   return AFFIRMATIVE_INTENT_PATTERN.test(text)
 }
 
+// Mentoria de Carreira: Fase 1 → Fase 2
+function shouldAdvanceToPhase2(
+  phase: z.infer<typeof chatRequestSchema>['phase'],
+  userMessage: string,
+  history: ChatHistory
+): boolean {
+  if (phase !== 'PHASE_1_DIAGNOSTICO') return false
+  if (!isAffirmativeForPhaseAdvance(userMessage)) return false
+  const latestAssistant = findLatestAssistantBeforeCurrentUser(history)
+  return ASK_TO_ADVANCE_PHASE_2_PATTERN.test(latestAssistant)
+}
+
+// PDI Expresso: Fase 1 → Fase 3 diretamente (pula Fase 2)
+function shouldAdvanceDirectlyToPhase3(
+  phase: z.infer<typeof chatRequestSchema>['phase'],
+  userMessage: string,
+  history: ChatHistory
+): boolean {
+  if (phase !== 'PHASE_1_DIAGNOSTICO') return false
+  if (!isAffirmativeForPhaseAdvance(userMessage)) return false
+  const latestAssistant = findLatestAssistantBeforeCurrentUser(history)
+  return ASK_TO_ADVANCE_DIRECT_PATTERN.test(latestAssistant)
+}
+
+// Mentoria de Carreira: Fase 2 → Fase 3
 function shouldAdvanceToPhase3(
   phase: z.infer<typeof chatRequestSchema>['phase'],
   userMessage: string,
-  history: Array<{ role: 'USER' | 'ASSISTANT' | 'SYSTEM'; content: string }>
+  history: ChatHistory
 ): boolean {
   if (phase !== 'PHASE_2_ADAPTATIVO') return false
   if (!isAffirmativeForPhaseAdvance(userMessage)) return false
-
   const latestAssistant = findLatestAssistantBeforeCurrentUser(history)
   return PHASE_2_CLOSING_PATTERN.test(latestAssistant)
 }
 
+// Ambas as personas: Fase 3 → Fase 4
 function shouldAdvanceToPhase4(
   phase: z.infer<typeof chatRequestSchema>['phase'],
   userMessage: string,
-  history: Array<{ role: 'USER' | 'ASSISTANT' | 'SYSTEM'; content: string }>
+  history: ChatHistory
 ): boolean {
   if (phase !== 'PHASE_3_DIRECAO') return false
   if (!isAffirmativeForPhaseAdvance(userMessage)) return false
-
   const latestAssistant = findLatestAssistantBeforeCurrentUser(history)
   return ASK_ABOUT_PATH_PATTERN.test(latestAssistant)
-}
-
-function shouldAdvanceToPhase2(
-  phase: z.infer<typeof chatRequestSchema>['phase'],
-  userMessage: string,
-  history: Array<{ role: 'USER' | 'ASSISTANT' | 'SYSTEM'; content: string }>
-): boolean {
-  if (phase !== 'PHASE_1_DIAGNOSTICO') return false
-  if (!isAffirmativeForPhaseAdvance(userMessage)) return false
-
-  const latestAssistant = findLatestAssistantBeforeCurrentUser(history)
-  return ASK_TO_ADVANCE_PHASE_2_PATTERN.test(latestAssistant)
 }
 
 export async function POST(
@@ -96,6 +115,7 @@ export async function POST(
     const parsed = chatRequestSchema.parse(body)
 
     const pdi = await ensurePdiForUser(pdiId, user.id)
+    const persona = getPersonaById(pdi.personaId)
 
     const conversation = await prisma.conversation.upsert({
       where: {
@@ -104,9 +124,7 @@ export async function POST(
           phase: parsed.phase,
         },
       },
-      update: {
-        status: 'ACTIVE',
-      },
+      update: { status: 'ACTIVE' },
       create: {
         projectId: pdi.id,
         phase: parsed.phase,
@@ -123,86 +141,16 @@ export async function POST(
     })
 
     const history = await prisma.message.findMany({
-      where: {
-        conversationId: conversation.id,
-      },
-      orderBy: {
-        createdAt: 'asc',
-      },
+      where: { conversationId: conversation.id },
+      orderBy: { createdAt: 'asc' },
     })
 
-    if (shouldAdvanceToPhase2(parsed.phase, parsed.message, history)) {
-      const phase2Conversation = await prisma.conversation.upsert({
-        where: {
-          projectId_phase: {
-            projectId: pdi.id,
-            phase: 'PHASE_2_ADAPTATIVO',
-          },
-        },
-        update: {
-          status: 'ACTIVE',
-        },
-        create: {
-          projectId: pdi.id,
-          phase: 'PHASE_2_ADAPTATIVO',
-          status: 'ACTIVE',
-        },
-      })
-
-      const existingPhase2Assistant = await prisma.message.findFirst({
-        where: {
-          conversationId: phase2Conversation.id,
-          role: 'ASSISTANT',
-        },
-        orderBy: {
-          createdAt: 'desc',
-        },
-      })
-
-      const phase2AssistantMessage =
-        existingPhase2Assistant ||
-        (await prisma.message.create({
-          data: {
-            conversationId: phase2Conversation.id,
-            role: 'ASSISTANT',
-            content: getPhase2BranchGateQuestionMessage(),
-          },
-        }))
-
-      await prisma.project.update({
-        where: { id: pdi.id },
-        data: {
-          currentPhase: 'PHASE_2_ADAPTATIVO',
-          currentScreen: PHASE_2_SCREEN,
-        },
-      })
-
-      return NextResponse.json({
-        conversationId: phase2Conversation.id,
-        assistantMessage: {
-          id: phase2AssistantMessage.id,
-          role: phase2AssistantMessage.role,
-          content: phase2AssistantMessage.content,
-          createdAt: phase2AssistantMessage.createdAt,
-        },
-        nextScreen: PHASE_2_SCREEN,
-      })
-    }
-
-    if (shouldAdvanceToPhase3(parsed.phase, parsed.message, history)) {
+    // ── Transição: PDI Expresso Fase 1 → Fase 3 (skip Phase 2) ──────────────
+    if (persona.skipsPhase2 && shouldAdvanceDirectlyToPhase3(parsed.phase, parsed.message, history)) {
       const phase3Conversation = await prisma.conversation.upsert({
-        where: {
-          projectId_phase: {
-            projectId: pdi.id,
-            phase: 'PHASE_3_DIRECAO',
-          },
-        },
+        where: { projectId_phase: { projectId: pdi.id, phase: 'PHASE_3_DIRECAO' } },
         update: { status: 'ACTIVE' },
-        create: {
-          projectId: pdi.id,
-          phase: 'PHASE_3_DIRECAO',
-          status: 'ACTIVE',
-        },
+        create: { projectId: pdi.id, phase: 'PHASE_3_DIRECAO', status: 'ACTIVE' },
       })
 
       const existingPhase3Assistant = await prisma.message.findFirst({
@@ -216,16 +164,13 @@ export async function POST(
           data: {
             conversationId: phase3Conversation.id,
             role: 'ASSISTANT',
-            content: await buildPhase3InitialMessage(history),
+            content: await buildPhase3InitialMessage(history, persona),
           },
         }))
 
       await prisma.project.update({
         where: { id: pdi.id },
-        data: {
-          currentPhase: 'PHASE_3_DIRECAO',
-          currentScreen: PHASE_3_SCREEN,
-        },
+        data: { currentPhase: 'PHASE_3_DIRECAO', currentScreen: PHASE_3_SCREEN },
       })
 
       return NextResponse.json({
@@ -240,6 +185,87 @@ export async function POST(
       })
     }
 
+    // ── Transição: Mentoria de Carreira Fase 1 → Fase 2 ─────────────────────
+    if (!persona.skipsPhase2 && shouldAdvanceToPhase2(parsed.phase, parsed.message, history)) {
+      const phase2Conversation = await prisma.conversation.upsert({
+        where: { projectId_phase: { projectId: pdi.id, phase: 'PHASE_2_ADAPTATIVO' } },
+        update: { status: 'ACTIVE' },
+        create: { projectId: pdi.id, phase: 'PHASE_2_ADAPTATIVO', status: 'ACTIVE' },
+      })
+
+      const existingPhase2Assistant = await prisma.message.findFirst({
+        where: { conversationId: phase2Conversation.id, role: 'ASSISTANT' },
+        orderBy: { createdAt: 'desc' },
+      })
+
+      const phase2AssistantMessage =
+        existingPhase2Assistant ||
+        (await prisma.message.create({
+          data: {
+            conversationId: phase2Conversation.id,
+            role: 'ASSISTANT',
+            content: getPhase2BranchGateQuestionMessage(persona),
+          },
+        }))
+
+      await prisma.project.update({
+        where: { id: pdi.id },
+        data: { currentPhase: 'PHASE_2_ADAPTATIVO', currentScreen: PHASE_2_SCREEN },
+      })
+
+      return NextResponse.json({
+        conversationId: phase2Conversation.id,
+        assistantMessage: {
+          id: phase2AssistantMessage.id,
+          role: phase2AssistantMessage.role,
+          content: phase2AssistantMessage.content,
+          createdAt: phase2AssistantMessage.createdAt,
+        },
+        nextScreen: PHASE_2_SCREEN,
+      })
+    }
+
+    // ── Transição: Mentoria de Carreira Fase 2 → Fase 3 ─────────────────────
+    if (shouldAdvanceToPhase3(parsed.phase, parsed.message, history)) {
+      const phase3Conversation = await prisma.conversation.upsert({
+        where: { projectId_phase: { projectId: pdi.id, phase: 'PHASE_3_DIRECAO' } },
+        update: { status: 'ACTIVE' },
+        create: { projectId: pdi.id, phase: 'PHASE_3_DIRECAO', status: 'ACTIVE' },
+      })
+
+      const existingPhase3Assistant = await prisma.message.findFirst({
+        where: { conversationId: phase3Conversation.id, role: 'ASSISTANT' },
+        orderBy: { createdAt: 'desc' },
+      })
+
+      const phase3AssistantMessage =
+        existingPhase3Assistant ||
+        (await prisma.message.create({
+          data: {
+            conversationId: phase3Conversation.id,
+            role: 'ASSISTANT',
+            content: await buildPhase3InitialMessage(history, persona),
+          },
+        }))
+
+      await prisma.project.update({
+        where: { id: pdi.id },
+        data: { currentPhase: 'PHASE_3_DIRECAO', currentScreen: PHASE_3_SCREEN },
+      })
+
+      return NextResponse.json({
+        conversationId: phase3Conversation.id,
+        assistantMessage: {
+          id: phase3AssistantMessage.id,
+          role: phase3AssistantMessage.role,
+          content: phase3AssistantMessage.content,
+          createdAt: phase3AssistantMessage.createdAt,
+        },
+        nextScreen: PHASE_3_SCREEN,
+      })
+    }
+
+    // ── Transição: Fase 3 → Fase 4 (ambas as personas) ──────────────────────
     if (shouldAdvanceToPhase4(parsed.phase, parsed.message, history)) {
       const confirmContent =
         'Caminho confirmado. Vou montar o PDI completo agora. Clique em "Gerar PDI completo" no painel central para iniciar.'
@@ -269,10 +295,12 @@ export async function POST(
       })
     }
 
+    // ── Resposta normal da AI ────────────────────────────────────────────────
     const assistantContent = await buildAssistantReply(
       parsed.phase,
       parsed.message,
-      history
+      history,
+      persona
     )
 
     const assistantMessage = await prisma.message.create({

--- a/src/app/api/pdi/[pdiId]/persona/route.ts
+++ b/src/app/api/pdi/[pdiId]/persona/route.ts
@@ -3,7 +3,6 @@ import { z } from 'zod'
 import { prisma } from '@/lib/db/prisma'
 import { getOrCreateUserByClerkId, requireClerkUserId, UnauthorizedError } from '@/lib/auth/session'
 import { ensurePdiForUser, PdiNotFoundError } from '@/lib/pdi/access'
-import { PERSONA_REGISTRY } from '@/lib/pdi/personas'
 
 const patchPersonaSchema = z.object({
   personaId: z.enum(['mentoria-carreira', 'pdi-expresso']),
@@ -19,11 +18,6 @@ export async function PATCH(
     const user = await getOrCreateUserByClerkId(clerkId)
     const body = await request.json()
     const parsed = patchPersonaSchema.parse(body)
-
-    // Valida que a persona existe no registry
-    if (!PERSONA_REGISTRY[parsed.personaId]) {
-      return NextResponse.json({ error: 'INVALID_PERSONA' }, { status: 400 })
-    }
 
     const pdi = await ensurePdiForUser(pdiId, user.id)
 

--- a/src/app/api/pdi/[pdiId]/persona/route.ts
+++ b/src/app/api/pdi/[pdiId]/persona/route.ts
@@ -1,0 +1,73 @@
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+import { prisma } from '@/lib/db/prisma'
+import { getOrCreateUserByClerkId, requireClerkUserId, UnauthorizedError } from '@/lib/auth/session'
+import { ensurePdiForUser, PdiNotFoundError } from '@/lib/pdi/access'
+import { PERSONA_REGISTRY } from '@/lib/pdi/personas'
+
+const patchPersonaSchema = z.object({
+  personaId: z.enum(['mentoria-carreira', 'pdi-expresso']),
+})
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ pdiId: string }> }
+) {
+  try {
+    const { pdiId } = await params
+    const clerkId = await requireClerkUserId()
+    const user = await getOrCreateUserByClerkId(clerkId)
+    const body = await request.json()
+    const parsed = patchPersonaSchema.parse(body)
+
+    // Valida que a persona existe no registry
+    if (!PERSONA_REGISTRY[parsed.personaId]) {
+      return NextResponse.json({ error: 'INVALID_PERSONA' }, { status: 400 })
+    }
+
+    const pdi = await ensurePdiForUser(pdiId, user.id)
+
+    // Só permite trocar a persona se ainda estiver na Fase 1 (antes de qualquer progresso)
+    if (pdi.currentPhase !== 'PHASE_1_DIAGNOSTICO') {
+      return NextResponse.json(
+        { error: 'PERSONA_LOCKED', message: 'A persona só pode ser alterada antes de iniciar a jornada.' },
+        { status: 409 }
+      )
+    }
+
+    // Apaga mensagens da Fase 1 para reiniciar com a nova persona
+    const phase1Conversation = await prisma.conversation.findFirst({
+      where: { projectId: pdi.id, phase: 'PHASE_1_DIAGNOSTICO' },
+    })
+
+    if (phase1Conversation) {
+      await prisma.message.deleteMany({
+        where: { conversationId: phase1Conversation.id },
+      })
+    }
+
+    const updated = await prisma.project.update({
+      where: { id: pdi.id },
+      data: {
+        personaId: parsed.personaId,
+        currentScreen: 'phase-1-diagnostico',
+      },
+    })
+
+    return NextResponse.json({
+      personaId: updated.personaId,
+      currentScreen: updated.currentScreen,
+    })
+  } catch (error) {
+    if (error instanceof UnauthorizedError) {
+      return NextResponse.json({ error: 'UNAUTHORIZED' }, { status: 401 })
+    }
+    if (error instanceof PdiNotFoundError) {
+      return NextResponse.json({ error: 'PDI_NOT_FOUND' }, { status: 404 })
+    }
+    if (error instanceof z.ZodError) {
+      return NextResponse.json({ error: 'VALIDATION_ERROR', details: error.errors }, { status: 400 })
+    }
+    return NextResponse.json({ error: 'INTERNAL_ERROR' }, { status: 500 })
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,37 @@
+import Link from 'next/link'
+import { auth } from '@clerk/nextjs/server'
+import { redirect } from 'next/navigation'
+
+export default async function HomePage() {
+  const { userId } = await auth()
+
+  if (userId) {
+    redirect('/pdi/pdi-inicial/escolher-modo')
+  }
+
+  return (
+    <main className="hub" style={{ minHeight: '100vh', display: 'grid', placeItems: 'center' }}>
+      <section className="hub-section" style={{ maxWidth: 960 }}>
+        <div className="logo" style={{ justifyContent: 'center', marginBottom: 16 }}>
+          <div className="logo-mark">PDI</div>
+          <div className="logo-text">PDI Builder</div>
+        </div>
+        <h1 className="hub-title" style={{ textAlign: 'center', marginBottom: 12 }}>
+          Crie seu PDI com profundidade e execução real
+        </h1>
+        <p className="hub-subtitle" style={{ textAlign: 'center' }}>
+          Plataforma para construir o Plano de Desenvolvimento Individual com diagnóstico adaptativo,
+          geração estruturada de documento e revisões por chat com versionamento.
+        </p>
+        <div style={{ display: 'flex', justifyContent: 'center', gap: 12, marginTop: 24, flexWrap: 'wrap' }}>
+          <Link className="btn primary" href="/sign-in">
+            Entrar
+          </Link>
+          <Link className="btn secondary" href="/sign-up">
+            Criar conta
+          </Link>
+        </div>
+      </section>
+    </main>
+  )
+}

--- a/src/app/pdi/[pdiId]/[...screen]/page.tsx
+++ b/src/app/pdi/[pdiId]/[...screen]/page.tsx
@@ -1,0 +1,70 @@
+import { notFound } from 'next/navigation'
+import { PdiScreen } from '@/components/pdi/PdiScreen'
+import { getPdiPageData } from '@/lib/pdi/page-data'
+
+const allowedScreens = new Set([
+  'phase-1-diagnostico',
+  'phase-2-adaptativo',
+  'phase-3-direcao',
+  'phase-4-pdi/inicio',
+  'phase-4-pdi/avancado',
+  'phase-4-pdi/consolidado',
+  'phase-5-final/entregaveis',
+  'phase-5-final/revisao',
+] as const)
+
+type Screen =
+  | 'phase-1-diagnostico'
+  | 'phase-2-adaptativo'
+  | 'phase-3-direcao'
+  | 'phase-4-pdi/inicio'
+  | 'phase-4-pdi/avancado'
+  | 'phase-4-pdi/consolidado'
+  | 'phase-5-final/entregaveis'
+  | 'phase-5-final/revisao'
+
+export default async function PdiScreenPage({
+  params,
+}: {
+  params: Promise<{ pdiId: string; screen: string[] }>
+}) {
+  const { pdiId, screen } = await params
+  const screenKey = screen.join('/') as Screen
+
+  if (!allowedScreens.has(screenKey)) {
+    notFound()
+  }
+
+  const data = await getPdiPageData(pdiId)
+
+  const sectionsMap = Object.fromEntries(
+    data.sections
+      .filter((section) => data.latestDocument && section.documentId === data.latestDocument.id)
+      .map((section) => [section.sectionKey, section.content || ''])
+  )
+
+  return (
+    <PdiScreen
+      pdiId={pdiId}
+      pdiName={data.pdi.name}
+      screen={screenKey}
+      sectionsMap={sectionsMap}
+      mergedDocument={data.latestDocument?.fullContent || ''}
+      latestRevisionSummary={data.latestRevision?.summary || null}
+      conversations={data.conversations.map((conversation) => ({
+        phase: conversation.phase,
+        messages: conversation.messages.map((message) => ({
+          id: message.id,
+          role: message.role,
+          content: message.content,
+        })),
+      }))}
+      userProfile={{
+        name: data.user.name,
+        email: data.user.email,
+        avatarUrl: data.user.avatarUrl,
+      }}
+      persona={data.persona}
+    />
+  )
+}

--- a/src/app/pdi/[pdiId]/escolher-modo/page.tsx
+++ b/src/app/pdi/[pdiId]/escolher-modo/page.tsx
@@ -1,0 +1,28 @@
+import { redirect } from 'next/navigation'
+import { getPdiPageData } from '@/lib/pdi/page-data'
+import { ALL_PERSONAS } from '@/lib/pdi/personas'
+import { PersonaSelector } from '@/components/pdi/PersonaSelector'
+
+export default async function EscolherModoPage({
+  params,
+}: {
+  params: Promise<{ pdiId: string }>
+}) {
+  const { pdiId } = await params
+  const data = await getPdiPageData(pdiId)
+
+  // Se já avançou de Fase 1, não permite trocar
+  if (data.pdi.currentPhase !== 'PHASE_1_DIAGNOSTICO') {
+    redirect(`/pdi/${pdiId}/${data.pdi.currentScreen}`)
+  }
+
+  return (
+    <main className="hub" style={{ minHeight: '100vh', display: 'grid', placeItems: 'center' }}>
+      <PersonaSelector
+        pdiId={pdiId}
+        personas={ALL_PERSONAS}
+        currentPersonaId={data.pdi.personaId}
+      />
+    </main>
+  )
+}

--- a/src/app/pdi/[pdiId]/escolher-modo/page.tsx
+++ b/src/app/pdi/[pdiId]/escolher-modo/page.tsx
@@ -1,7 +1,7 @@
 import { redirect } from 'next/navigation'
 import { getPdiPageData } from '@/lib/pdi/page-data'
 import { ALL_PERSONAS } from '@/lib/pdi/personas'
-import { PersonaSelector } from '@/components/pdi/PersonaSelector'
+import { PersonaSelector, type PersonaOption } from '@/components/pdi/PersonaSelector'
 
 export default async function EscolherModoPage({
   params,
@@ -16,11 +16,23 @@ export default async function EscolherModoPage({
     redirect(`/pdi/${pdiId}/${data.pdi.currentScreen}`)
   }
 
+  // Mapeia para PersonaOption (somente campos string) antes de passar ao Client Component.
+  // PersonaManifest contém RegExp[] que não é serializável pela boundary Server→Client.
+  const personaOptions: PersonaOption[] = ALL_PERSONAS.map(
+    ({ id, displayName, shortDescription, estimatedTime, assistantName }) => ({
+      id,
+      displayName,
+      shortDescription,
+      estimatedTime,
+      assistantName,
+    })
+  )
+
   return (
     <main className="hub" style={{ minHeight: '100vh', display: 'grid', placeItems: 'center' }}>
       <PersonaSelector
         pdiId={pdiId}
-        personas={ALL_PERSONAS}
+        personas={personaOptions}
         currentPersonaId={data.pdi.personaId}
       />
     </main>

--- a/src/components/pdi/PdiScreen.tsx
+++ b/src/components/pdi/PdiScreen.tsx
@@ -4,6 +4,7 @@ import {
 } from '@/lib/pdi/chat-engine'
 import { isStructuredPhaseOutput } from '@/lib/pdi/structured-output'
 import { PDI_SECTION_ORDER, type PdiSectionKey } from '@/lib/pdi/orchestrator'
+import { type PersonaManifest, MENTORIA_CARREIRA_PERSONA } from '@/lib/pdi/personas'
 import { MarkdownContent } from './MarkdownContent'
 import { PdiShell } from './PdiShell'
 import { PhaseChatRail } from './PhaseChatRail'
@@ -55,6 +56,7 @@ interface PdiScreenProps {
     email?: string | null
     avatarUrl?: string | null
   }
+  persona?: PersonaManifest
 }
 
 function getConversationPhase(screen: ScreenKey) {
@@ -68,7 +70,8 @@ function getConversationPhase(screen: ScreenKey) {
 
 function initialMessagesForScreen(
   screen: ScreenKey,
-  conversations: ConversationPayload[]
+  conversations: ConversationPayload[],
+  persona: PersonaManifest
 ): ChatMessage[] {
   const phase = getConversationPhase(screen)
   if (!phase) return []
@@ -81,7 +84,7 @@ function initialMessagesForScreen(
       {
         id: 'phase-1-anchor',
         role: 'ASSISTANT',
-        content: getPhase1AnchorQuestionsMessage(),
+        content: getPhase1AnchorQuestionsMessage(persona),
       },
     ]
   }
@@ -91,7 +94,7 @@ function initialMessagesForScreen(
       {
         id: 'phase-2-gate',
         role: 'ASSISTANT',
-        content: getPhase2BranchGateQuestionMessage(),
+        content: getPhase2BranchGateQuestionMessage(persona),
       },
     ]
   }
@@ -101,7 +104,8 @@ function initialMessagesForScreen(
 
 function latestStructuredAssistantMessageForPhase(
   conversations: ConversationPayload[],
-  phase: string
+  phase: string,
+  extraPatterns: RegExp[] = []
 ): string | null {
   const conversation = conversations.find((item) => item.phase === phase)
   if (!conversation) return null
@@ -109,14 +113,18 @@ function latestStructuredAssistantMessageForPhase(
   for (let index = conversation.messages.length - 1; index >= 0; index -= 1) {
     const message = conversation.messages[index]
     if (message.role !== 'ASSISTANT') continue
-    if (!isStructuredPhaseOutput(message.content)) continue
+    if (!isStructuredPhaseOutput(message.content, extraPatterns)) continue
     return message.content
   }
 
   return null
 }
 
-function sidebarForScreen(screen: ScreenKey, sectionsMap: Record<string, string>) {
+function sidebarForScreen(
+  screen: ScreenKey,
+  sectionsMap: Record<string, string>,
+  persona: PersonaManifest
+) {
   const isPhase1 = screen === 'phase-1-diagnostico'
   const isPhase2 = screen === 'phase-2-adaptativo'
   const isPhase3 = screen === 'phase-3-direcao'
@@ -126,28 +134,40 @@ function sidebarForScreen(screen: ScreenKey, sectionsMap: Record<string, string>
   const isReview = screen === 'phase-5-final/revisao'
 
   const beforePhase4 = isPhase1 || isPhase2 || isPhase3
+  const skipsPhase2 = persona.skipsPhase2
+
+  const phase1Label = persona.phases?.PHASE_1_DIAGNOSTICO?.sidebarLabel ?? 'Diagnóstico Âncora'
+  const phase2Label = persona.phases?.PHASE_2_ADAPTATIVO?.sidebarLabel ?? 'Diagnóstico Adaptativo'
+  const phase3Label = persona.phases?.PHASE_3_DIRECAO?.sidebarLabel ?? 'Hipótese de Direção'
+  const phase5Label = persona.phases?.PHASE_5_FINAL?.sidebarLabel ?? 'Entregáveis Finais'
 
   return (
     <>
       <div className="nav-label">FASES</div>
       <div className={`nav-item ${isPhase1 ? 'active' : 'done'}`}>
-        <span>1. Diagnóstico Âncora</span>
+        <span>1. {phase1Label}</span>
         <span className={`badge ${isPhase1 ? 'warning' : 'success'}`}>{isPhase1 ? 'ATUAL' : 'OK'}</span>
       </div>
-      <div className={`nav-item ${isPhase2 ? 'active' : isPhase1 ? 'blocked' : 'done'}`}>
-        <span>2. Diagnóstico Adaptativo</span>
-        <span className={`badge ${isPhase2 ? 'warning' : isPhase1 ? 'info' : 'success'}`}>
-          {isPhase2 ? 'ATUAL' : isPhase1 ? 'BLOQ' : 'OK'}
-        </span>
-      </div>
+
+      {/* Fase 2 só aparece na persona Mentoria de Carreira */}
+      {!skipsPhase2 ? (
+        <div className={`nav-item ${isPhase2 ? 'active' : isPhase1 ? 'blocked' : 'done'}`}>
+          <span>2. {phase2Label}</span>
+          <span className={`badge ${isPhase2 ? 'warning' : isPhase1 ? 'info' : 'success'}`}>
+            {isPhase2 ? 'ATUAL' : isPhase1 ? 'BLOQ' : 'OK'}
+          </span>
+        </div>
+      ) : null}
+
       <div className={`nav-item ${isPhase3 ? 'active' : isPhase1 || isPhase2 ? 'blocked' : 'done'}`}>
-        <span>3. Hipótese de Direção</span>
+        <span>{skipsPhase2 ? '2.' : '3.'} {phase3Label}</span>
         <span className={`badge ${isPhase3 ? 'warning' : isPhase1 || isPhase2 ? 'info' : 'success'}`}>
           {isPhase3 ? 'ATUAL' : isPhase1 || isPhase2 ? 'BLOQ' : 'OK'}
         </span>
       </div>
+
       <div className={`nav-item ${isPhase4 ? 'active' : beforePhase4 ? 'blocked' : 'done'}`}>
-        <span>4. PDI Completo</span>
+        <span>{skipsPhase2 ? '3.' : '4.'} PDI Completo</span>
         <span className={`badge ${isPhase4 ? 'warning' : beforePhase4 ? 'info' : 'success'}`}>
           {isPhase4 ? 'ATUAL' : beforePhase4 ? 'BLOQ' : 'OK'}
         </span>
@@ -173,7 +193,7 @@ function sidebarForScreen(screen: ScreenKey, sectionsMap: Record<string, string>
       ) : null}
 
       <div className={`nav-item ${isPhase5 ? 'active' : isReview ? 'done' : isPhase4Consolidado ? 'active' : 'blocked'}`}>
-        <span>5. Entregáveis Finais</span>
+        <span>{skipsPhase2 ? '4.' : '5.'} {phase5Label}</span>
         <span className={`badge ${isPhase5 ? 'warning' : isReview ? 'success' : isPhase4Consolidado ? 'brand' : 'info'}`}>
           {isPhase5 ? 'ATUAL' : isReview ? 'OK' : isPhase4Consolidado ? 'PRÓXIMO' : 'BLOQ'}
         </span>
@@ -199,6 +219,7 @@ function workspaceForScreen(
   phase2StructuredOutput: string | null,
   phase3StructuredOutput: string | null,
   phase5StructuredOutput: string | null,
+  persona: PersonaManifest,
   latestRevisionSummary?: string | null
 ) {
   if (screen === 'phase-4-pdi/inicio') {
@@ -234,14 +255,18 @@ function workspaceForScreen(
     )
   }
 
+  const phase1Label = persona.phases?.PHASE_1_DIAGNOSTICO?.sidebarLabel ?? 'Diagnóstico Âncora'
+  const phase2Label = persona.phases?.PHASE_2_ADAPTATIVO?.sidebarLabel ?? 'Diagnóstico Adaptativo'
+  const phase3Label = persona.phases?.PHASE_3_DIRECAO?.sidebarLabel ?? 'Hipótese de Direção'
+
   if (screen === 'phase-1-diagnostico') {
     return (
       <>
         <header className="workspace-header">
-          <div className="workspace-breadcrumb">Fase 1 · Diagnóstico Âncora</div>
+          <div className="workspace-breadcrumb">Fase 1 · {phase1Label}</div>
           <h1 className="workspace-title">Mapeamento do ponto de partida</h1>
           <p className="workspace-subtitle">
-            A conversa no chat conduz as perguntas âncora e registra as respostas confirmadas desta sessão.
+            A conversa no chat conduz as perguntas iniciais e registra as respostas confirmadas desta sessão.
           </p>
         </header>
         <section className="workspace-body">
@@ -259,7 +284,7 @@ function workspaceForScreen(
             <div className="card-header"><h2 className="card-title">Como esta fase funciona</h2></div>
             <div className="card-body">
               <div className="callout info">
-                O assistente conduz as 4 perguntas iniciais, uma por vez, diretamente no chat. Responda no painel à direita para seguir para a fase adaptativa.
+                O assistente conduz as perguntas iniciais, uma por vez, diretamente no chat. Responda no painel à direita para seguir para a próxima etapa.
               </div>
             </div>
           </article>
@@ -272,7 +297,7 @@ function workspaceForScreen(
     return (
       <>
         <header className="workspace-header">
-          <div className="workspace-breadcrumb">Fase 2 · Diagnóstico Adaptativo</div>
+          <div className="workspace-breadcrumb">Fase 2 · {phase2Label}</div>
           <h1 className="workspace-title">Classificação do ramo e perguntas dinâmicas</h1>
           <p className="workspace-subtitle">O mentor analisa seu obstáculo e aprofunda com perguntas específicas do padrão identificado.</p>
         </header>
@@ -305,15 +330,15 @@ function workspaceForScreen(
     return (
       <>
         <header className="workspace-header">
-          <div className="workspace-breadcrumb">Fase 3 · Hipótese de Direção</div>
-          <h1 className="workspace-title">Síntese estratégica e escolha de caminho</h1>
-          <p className="workspace-subtitle">O mentor sintetiza o diagnóstico, mapeia caminhos possíveis e apresenta uma recomendação fundamentada.</p>
+          <div className="workspace-breadcrumb">Fase 3 · {phase3Label}</div>
+          <h1 className="workspace-title">Síntese e escolha de caminho</h1>
+          <p className="workspace-subtitle">O especialista sintetiza o diagnóstico, mapeia caminhos possíveis e apresenta uma recomendação fundamentada.</p>
         </header>
         <section className="workspace-body">
           {phase3StructuredOutput ? (
             <article className="card">
               <div className="card-header">
-                <h2 className="card-title">Direção estratégica</h2>
+                <h2 className="card-title">Proposta de direção</h2>
               </div>
               <div className="card-body">
                 <MarkdownContent content={phase3StructuredOutput} />
@@ -324,7 +349,7 @@ function workspaceForScreen(
               <div className="card-header"><h2 className="card-title">Em andamento</h2></div>
               <div className="card-body">
                 <div className="callout info">
-                  O mentor está elaborando a síntese do seu diagnóstico e os caminhos possíveis. A direção estratégica recomendada aparecerá aqui para você confirmar ou ajustar via chat.
+                  O especialista está elaborando a síntese do seu diagnóstico e os caminhos possíveis. A proposta recomendada aparecerá aqui para você confirmar ou ajustar via chat.
                 </div>
               </div>
             </article>
@@ -411,6 +436,7 @@ function chatForScreen(
   screen: ScreenKey,
   conversations: ConversationPayload[],
   userProfile: PdiScreenProps['userProfile'],
+  persona: PersonaManifest,
   latestRevisionSummary?: string | null
 ) {
   if (screen.startsWith('phase-4-pdi')) {
@@ -435,46 +461,48 @@ function chatForScreen(
     return <RevisionChatRail pdiId={pdiId} initialSummary={latestRevisionSummary} />
   }
 
+  const extraPatterns = persona.structuredOutputExtraPatterns
+
   const config =
     screen === 'phase-1-diagnostico'
       ? {
           phase: 'PHASE_1_DIAGNOSTICO' as const,
-          phaseLabel: 'Fase 1/5',
+          phaseLabel: 'Fase 1',
           progress: 20,
-          progressText: 'Diagnóstico âncora em andamento',
-          placeholder: 'Responda ao mentor...',
+          progressText: 'Coleta inicial em andamento',
+          placeholder: 'Responda ao especialista...',
           ctaPrimary: 'Enviar',
           promoteStructuredAssistantOutputToWorkspace: true,
           advancePhase: 'PHASE_1_DIAGNOSTICO' as const,
-          advanceLabel: 'Avançar para o Diagnóstico Adaptativo →',
+          advanceLabel: persona.ctaLabels.phase1Advance,
         }
       : screen === 'phase-2-adaptativo'
         ? {
             phase: 'PHASE_2_ADAPTATIVO' as const,
-            phaseLabel: 'Fase 2/5',
+            phaseLabel: 'Fase 2',
             progress: 38,
             progressText: 'Diagnóstico adaptativo com triangulação de mercado',
             placeholder: 'Responda ao mentor...',
             ctaPrimary: 'Enviar',
             promoteStructuredAssistantOutputToWorkspace: true,
             advancePhase: 'PHASE_2_ADAPTATIVO' as const,
-            advanceLabel: 'Avançar para a Hipótese de Direção →',
+            advanceLabel: persona.phases?.PHASE_2_ADAPTATIVO?.advanceLabel ?? 'Avançar para a Hipótese de Direção →',
           }
         : screen === 'phase-3-direcao'
           ? {
               phase: 'PHASE_3_DIRECAO' as const,
-              phaseLabel: 'Fase 3/5',
+              phaseLabel: 'Fase 3',
               progress: 54,
-              progressText: 'Hipótese de direção pronta para validação',
+              progressText: 'Proposta pronta para validação',
               placeholder: 'Peça ajustes ou escreva sua confirmação...',
               ctaPrimary: 'Enviar',
               promoteStructuredAssistantOutputToWorkspace: true,
               advancePhase: 'PHASE_3_DIRECAO' as const,
-              advanceLabel: 'Confirmar direção e gerar PDI completo →',
+              advanceLabel: persona.ctaLabels.phase3Confirm,
             }
           : {
               phase: 'PHASE_5_FINAL' as const,
-              phaseLabel: 'Fase 5/5',
+              phaseLabel: 'Fase 5',
               progress: 100,
               progressText: 'Entregáveis finais prontos para formalização',
               placeholder: 'Peça ajustes no documento...',
@@ -486,17 +514,19 @@ function chatForScreen(
     <PhaseChatRail
       pdiId={pdiId}
       phase={config.phase}
-      title="Mentoria de Carreira"
+      title={persona.chatTitle}
       phaseLabel={config.phaseLabel}
       progress={config.progress}
       progressText={config.progressText}
       placeholder={config.placeholder}
       ctaPrimary={config.ctaPrimary}
       promoteStructuredAssistantOutputToWorkspace={config.promoteStructuredAssistantOutputToWorkspace}
-      initialMessages={initialMessagesForScreen(screen, conversations)}
+      initialMessages={initialMessagesForScreen(screen, conversations, persona)}
       userProfile={userProfile}
       advancePhase={'advancePhase' in config ? config.advancePhase : undefined}
       advanceLabel={'advanceLabel' in config ? config.advanceLabel : undefined}
+      assistantName={persona.assistantName}
+      extraStructuredOutputPatterns={extraPatterns}
     />
   )
 }
@@ -510,22 +540,29 @@ export function PdiScreen({
   latestRevisionSummary,
   conversations,
   userProfile,
+  persona = MENTORIA_CARREIRA_PERSONA,
 }: PdiScreenProps) {
+  const extraPatterns = persona.structuredOutputExtraPatterns
+
   const phase1StructuredOutput = latestStructuredAssistantMessageForPhase(
     conversations,
-    'PHASE_1_DIAGNOSTICO'
+    'PHASE_1_DIAGNOSTICO',
+    extraPatterns
   )
   const phase2StructuredOutput = latestStructuredAssistantMessageForPhase(
     conversations,
-    'PHASE_2_ADAPTATIVO'
+    'PHASE_2_ADAPTATIVO',
+    extraPatterns
   )
   const phase3StructuredOutput = latestStructuredAssistantMessageForPhase(
     conversations,
-    'PHASE_3_DIRECAO'
+    'PHASE_3_DIRECAO',
+    extraPatterns
   )
   const phase5StructuredOutput = latestStructuredAssistantMessageForPhase(
     conversations,
-    'PHASE_5_FINAL'
+    'PHASE_5_FINAL',
+    extraPatterns
   )
 
   return (
@@ -533,7 +570,7 @@ export function PdiScreen({
       pdiId={pdiId}
       pdiName={pdiName}
       pdiIdLabel={screen.toUpperCase().replaceAll('-', ' ').replaceAll('/', ' · ')}
-      sidebarNav={sidebarForScreen(screen, sectionsMap)}
+      sidebarNav={sidebarForScreen(screen, sectionsMap, persona)}
       workspace={workspaceForScreen(
         pdiId,
         screen,
@@ -543,9 +580,10 @@ export function PdiScreen({
         phase2StructuredOutput,
         phase3StructuredOutput,
         phase5StructuredOutput,
+        persona,
         latestRevisionSummary
       )}
-      chat={chatForScreen(pdiId, screen, conversations, userProfile, latestRevisionSummary)}
+      chat={chatForScreen(pdiId, screen, conversations, userProfile, persona, latestRevisionSummary)}
       userProfile={userProfile}
     />
   )

--- a/src/components/pdi/PdiScreen.tsx
+++ b/src/components/pdi/PdiScreen.tsx
@@ -461,8 +461,6 @@ function chatForScreen(
     return <RevisionChatRail pdiId={pdiId} initialSummary={latestRevisionSummary} />
   }
 
-  const extraPatterns = persona.structuredOutputExtraPatterns
-
   const config =
     screen === 'phase-1-diagnostico'
       ? {
@@ -526,7 +524,7 @@ function chatForScreen(
       advancePhase={'advancePhase' in config ? config.advancePhase : undefined}
       advanceLabel={'advanceLabel' in config ? config.advanceLabel : undefined}
       assistantName={persona.assistantName}
-      extraStructuredOutputPatterns={extraPatterns}
+      personaId={persona.id}
     />
   )
 }

--- a/src/components/pdi/PersonaSelector.tsx
+++ b/src/components/pdi/PersonaSelector.tsx
@@ -1,0 +1,158 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import { useState } from 'react'
+import type { PersonaManifest } from '@/lib/pdi/personas'
+
+interface PersonaSelectorProps {
+  pdiId: string
+  personas: PersonaManifest[]
+  currentPersonaId: string
+}
+
+export function PersonaSelector({ pdiId, personas, currentPersonaId }: PersonaSelectorProps) {
+  const router = useRouter()
+  const [loading, setLoading] = useState<string | null>(null)
+
+  async function selectPersona(personaId: string) {
+    if (loading) return
+    setLoading(personaId)
+
+    try {
+      const response = await fetch(`/api/pdi/${pdiId}/persona`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ personaId }),
+      })
+
+      if (!response.ok) {
+        const error = await response.json()
+        if (error.error === 'PERSONA_LOCKED') {
+          alert('A modalidade não pode ser alterada após o início da jornada.')
+          return
+        }
+        throw new Error(error.message || 'Erro ao selecionar modalidade')
+      }
+
+      router.push(`/pdi/${pdiId}/phase-1-diagnostico`)
+      router.refresh()
+    } catch {
+      alert('Erro ao salvar a modalidade. Tente novamente.')
+    } finally {
+      setLoading(null)
+    }
+  }
+
+  return (
+    <section className="hub-section" style={{ maxWidth: 880, width: '100%' }}>
+      <div className="hub-header">
+        <div
+          className="logo"
+          style={{ justifyContent: 'center', marginBottom: 16, display: 'flex', alignItems: 'center', gap: 8 }}
+        >
+          <div className="logo-mark">PDI</div>
+          <div className="logo-text">PDI Builder</div>
+        </div>
+        <h1 className="hub-title">Escolha a modalidade do seu PDI</h1>
+        <p className="hub-subtitle">
+          Selecione como quer construir seu Plano de Desenvolvimento Individual. Você pode escolher um caminho
+          mais rápido e operacional, ou um diagnóstico profundo com triangulação de mercado.
+        </p>
+      </div>
+
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fit, minmax(320px, 1fr))',
+          gap: 20,
+          marginTop: 32,
+        }}
+      >
+        {personas.map((persona) => {
+          const isActive = persona.id === currentPersonaId
+          const isLoadingThis = loading === persona.id
+
+          return (
+            <button
+              key={persona.id}
+              onClick={() => selectPersona(persona.id)}
+              disabled={loading !== null}
+              style={{
+                border: `2px solid ${isActive ? 'var(--color-brand-500, #3b82f6)' : 'var(--color-border)'}`,
+                borderRadius: 'var(--radius-lg)',
+                background: isActive ? 'var(--color-info-light, #eff6ff)' : '#fff',
+                padding: '28px 24px',
+                textAlign: 'left',
+                cursor: loading ? 'not-allowed' : 'pointer',
+                opacity: loading && !isLoadingThis ? 0.6 : 1,
+                transition: 'border-color 0.15s, box-shadow 0.15s',
+                boxShadow: isActive ? '0 0 0 3px rgba(59,130,246,0.15)' : 'var(--shadow-sm)',
+              }}
+            >
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: 12 }}>
+                <h2 style={{ margin: 0, fontSize: 'var(--font-size-lg)', fontWeight: 'var(--font-weight-bold)' }}>
+                  {persona.displayName}
+                </h2>
+                <span
+                  style={{
+                    fontSize: 11,
+                    fontWeight: 600,
+                    padding: '3px 8px',
+                    borderRadius: 'var(--radius-pill)',
+                    background: 'var(--color-bg-muted)',
+                    color: 'var(--color-text-secondary)',
+                    whiteSpace: 'nowrap',
+                    marginLeft: 8,
+                  }}
+                >
+                  {persona.estimatedTime}
+                </span>
+              </div>
+
+              <p
+                style={{
+                  margin: '0 0 16px',
+                  fontSize: 'var(--font-size-sm)',
+                  color: 'var(--color-text-secondary)',
+                  lineHeight: 1.6,
+                }}
+              >
+                {persona.shortDescription}
+              </p>
+
+              <div
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 6,
+                  fontSize: 'var(--font-size-xs)',
+                  color: 'var(--color-text-tertiary)',
+                  marginBottom: 20,
+                }}
+              >
+                <span>Assistente:</span>
+                <strong style={{ color: 'var(--color-text-secondary)' }}>{persona.assistantName}</strong>
+              </div>
+
+              <div
+                className={`btn primary`}
+                style={{
+                  display: 'inline-block',
+                  pointerEvents: 'none',
+                  fontSize: 'var(--font-size-sm)',
+                  padding: '9px 20px',
+                }}
+              >
+                {isLoadingThis
+                  ? 'Configurando...'
+                  : isActive
+                    ? 'Selecionado ✓'
+                    : 'Selecionar esta modalidade'}
+              </div>
+            </button>
+          )
+        })}
+      </div>
+    </section>
+  )
+}

--- a/src/components/pdi/PersonaSelector.tsx
+++ b/src/components/pdi/PersonaSelector.tsx
@@ -2,11 +2,20 @@
 
 import { useRouter } from 'next/navigation'
 import { useState } from 'react'
-import type { PersonaManifest } from '@/lib/pdi/personas'
+
+/** Subconjunto serializável de PersonaManifest — apenas campos string usados pela UI.
+ *  Evita passar RegExp[] (structuredOutputExtraPatterns) de Server para Client Component. */
+export interface PersonaOption {
+  id: string
+  displayName: string
+  shortDescription: string
+  estimatedTime: string
+  assistantName: string
+}
 
 interface PersonaSelectorProps {
   pdiId: string
-  personas: PersonaManifest[]
+  personas: PersonaOption[]
   currentPersonaId: string
 }
 

--- a/src/components/pdi/PhaseChatRail.tsx
+++ b/src/components/pdi/PhaseChatRail.tsx
@@ -37,6 +37,8 @@ interface PhaseChatRailProps {
   userProfile: UserProfile
   advancePhase?: 'PHASE_1_DIAGNOSTICO' | 'PHASE_2_ADAPTATIVO' | 'PHASE_3_DIRECAO'
   advanceLabel?: string
+  assistantName?: string
+  extraStructuredOutputPatterns?: RegExp[]
 }
 
 const EMPTY_MESSAGES: ChatMessage[] = []
@@ -56,6 +58,8 @@ export function PhaseChatRail({
   userProfile,
   advancePhase,
   advanceLabel,
+  assistantName = 'Mentor Executivo',
+  extraStructuredOutputPatterns = [],
 }: PhaseChatRailProps) {
   const router = useRouter()
   const [input, setInput] = useState('')
@@ -84,9 +88,9 @@ export function PhaseChatRail({
       messages.filter((message) => {
         if (!promoteStructuredAssistantOutputToWorkspace) return true
         if (message.role !== 'ASSISTANT') return true
-        return !isStructuredPhaseOutput(message.content)
+        return !isStructuredPhaseOutput(message.content, extraStructuredOutputPatterns)
       }),
-    [messages, promoteStructuredAssistantOutputToWorkspace]
+    [messages, promoteStructuredAssistantOutputToWorkspace, extraStructuredOutputPatterns]
   )
 
   // Verifica se o último assistente enviou o bloco de fechamento —
@@ -97,11 +101,11 @@ export function PhaseChatRail({
     for (let i = messages.length - 1; i >= 0; i--) {
       const msg = messages[i]
       if (msg.role === 'ASSISTANT') {
-        return isStructuredPhaseOutput(msg.content)
+        return isStructuredPhaseOutput(msg.content, extraStructuredOutputPatterns)
       }
     }
     return false
-  }, [messages, advancePhase])
+  }, [messages, advancePhase, extraStructuredOutputPatterns])
 
   async function handleAdvance() {
     if (!advancePhase || isAdvancing) return
@@ -180,7 +184,7 @@ export function PhaseChatRail({
 
       const shouldPromoteToWorkspace =
         promoteStructuredAssistantOutputToWorkspace &&
-        isStructuredPhaseOutput(assistantMessage.content)
+        isStructuredPhaseOutput(assistantMessage.content, extraStructuredOutputPatterns)
 
       setMessages((prev) => (shouldPromoteToWorkspace ? prev : [...prev, assistantMessage]))
 
@@ -266,7 +270,7 @@ export function PhaseChatRail({
             </div>
             <div className={`chat-bubble ${message.role === 'USER' ? 'user' : ''}`} style={message.role === 'USER' ? { whiteSpace: 'pre-line' } : undefined}>
               <span className="chat-author">
-                {message.role === 'USER' ? userProfile.name || 'Você' : 'Mentor Executivo'}
+                {message.role === 'USER' ? userProfile.name || 'Você' : assistantName}
               </span>
               {message.role === 'USER' ? message.content : <MarkdownContent content={message.content} />}
             </div>

--- a/src/components/pdi/PhaseChatRail.tsx
+++ b/src/components/pdi/PhaseChatRail.tsx
@@ -3,6 +3,7 @@
 import { useRouter } from 'next/navigation'
 import { useEffect, useMemo, useRef, useState, type KeyboardEvent } from 'react'
 import { isStructuredPhaseOutput } from '@/lib/pdi/structured-output'
+import { getPersonaById } from '@/lib/pdi/personas'
 import { MarkdownContent } from './MarkdownContent'
 
 interface ChatMessage {
@@ -38,7 +39,9 @@ interface PhaseChatRailProps {
   advancePhase?: 'PHASE_1_DIAGNOSTICO' | 'PHASE_2_ADAPTATIVO' | 'PHASE_3_DIRECAO'
   advanceLabel?: string
   assistantName?: string
-  extraStructuredOutputPatterns?: RegExp[]
+  /** ID da persona ativa. Padrões de output estruturado são derivados internamente
+   *  a partir do registry para evitar serialização de RegExp por Server→Client. */
+  personaId?: string
 }
 
 const EMPTY_MESSAGES: ChatMessage[] = []
@@ -59,8 +62,13 @@ export function PhaseChatRail({
   advancePhase,
   advanceLabel,
   assistantName = 'Mentor Executivo',
-  extraStructuredOutputPatterns = [],
+  personaId,
 }: PhaseChatRailProps) {
+  // Deriva os padrões de output estruturado a partir do registry (não serializa RegExp)
+  const extraStructuredOutputPatterns = useMemo(
+    () => (personaId ? getPersonaById(personaId).structuredOutputExtraPatterns : []),
+    [personaId]
+  )
   const router = useRouter()
   const [input, setInput] = useState('')
   const [isLoading, setIsLoading] = useState(false)

--- a/src/lib/pdi/chat-engine.ts
+++ b/src/lib/pdi/chat-engine.ts
@@ -2,32 +2,26 @@ import type { ConversationPhase, Message } from '@prisma/client'
 import { chatWithAI } from '@/lib/ai/client'
 import { buildPdiChatSystemPrompt } from './prompts'
 import { isStructuredPhaseOutput } from './structured-output'
+import { type PersonaManifest, MENTORIA_CARREIRA_PERSONA } from './personas'
 
-export function getPhase1AnchorQuestionsMessage(): string {
-  return PHASE1_ANCHOR_QUESTIONS[0]
+export function getPhase1AnchorQuestionsMessage(persona?: PersonaManifest): string {
+  const questions = persona?.anchorQuestions ?? MENTORIA_CARREIRA_PERSONA.anchorQuestions
+  return questions[0]
 }
 
-export function getPhase2BranchGateQuestionMessage(): string {
-  return PHASE2_BRANCH_GATE_QUESTION
+export function getPhase2BranchGateQuestionMessage(persona?: PersonaManifest): string {
+  const gateQuestion =
+    persona?.phase2GateQuestion ?? MENTORIA_CARREIRA_PERSONA.phase2GateQuestion
+  return gateQuestion ?? ''
 }
-
-const PHASE1_ANCHOR_QUESTIONS = [
-  '1. Onde você está hoje? (cargo, senioridade, empresa/setor, regime de trabalho)',
-  '2. Qual resultado concreto você quer em 12 meses? (cargo, impacto e faixa salarial)',
-  '3. Na sua visão, qual é o maior obstáculo entre o estado atual e o objetivo?',
-  '4. Qual sua formação acadêmica atual? (curso, nível e status)',
-] as const
-
-const PHASE2_BRANCH_GATE_QUESTION =
-  'Agora vou aprofundar o diagnóstico. Me conta: no seu dia a dia, como esse obstáculo aparece concretamente? Pode ser uma situação recente, um padrão que se repete ou uma tensão que você sente com frequência.'
 
 const FALLBACK_BY_PHASE: Record<ConversationPhase, string> = {
   PHASE_1_DIAGNOSTICO:
-    'Não consegui concluir o diagnóstico âncora agora. Reenvie suas respostas para eu identificar o obstáculo principal e seguir para a Fase 2.',
+    'Não consegui concluir a coleta inicial agora. Reenvie suas respostas para eu identificar o obstáculo principal e seguir para a próxima etapa.',
   PHASE_2_ADAPTATIVO:
     'Não consegui concluir o diagnóstico adaptativo agora. Reenvie sua última resposta para eu classificar o ramo e fechar ✅ Confirmado / ⚠️ Falta.',
   PHASE_3_DIRECAO:
-    'Não consegui concluir a hipótese de direção agora. Reenvie para eu retornar os caminhos e recomendação.',
+    'Não consegui concluir a proposta de direção agora. Reenvie para eu retornar os caminhos e recomendação.',
   PHASE_5_FINAL:
     'Não consegui atualizar os entregáveis finais agora. Reenvie o ajuste desejado para eu recalibrar o documento.',
   PHASE_REVISAO:
@@ -49,10 +43,10 @@ function countUserMessages(history: Message[]): number {
   return history.filter((message) => message.role === 'USER').length
 }
 
-function normalizePhase2SingleQuestion(content: string): string {
+function normalizePhase2SingleQuestion(content: string, extraPatterns: RegExp[] = []): string {
   const text = content.trim()
   if (!text) return text
-  if (isStructuredPhaseOutput(text)) return text
+  if (isStructuredPhaseOutput(text, extraPatterns)) return text
 
   const questionMatches = text
     .split(/\n+/)
@@ -78,14 +72,17 @@ function normalizePhase2SingleQuestion(content: string): string {
   return `${intro}\n\n${firstQuestion}`
 }
 
-export async function buildPhase3InitialMessage(phase2History: Message[]): Promise<string> {
+export async function buildPhase3InitialMessage(
+  phase2History: Message[],
+  persona?: PersonaManifest
+): Promise<string> {
   try {
     const aiMessages = toAIMessage(phase2History)
     aiMessages.push({ role: 'user', content: 'Pode avançar para a proposta de direção.' })
 
     const response = await chatWithAI({
       phase: 'pdi_chat',
-      systemPrompt: buildPdiChatSystemPrompt('PHASE_3_DIRECAO'),
+      systemPrompt: buildPdiChatSystemPrompt('PHASE_3_DIRECAO', persona),
       messages: aiMessages,
     })
 
@@ -99,17 +96,19 @@ export async function buildPhase3InitialMessage(phase2History: Message[]): Promi
 export async function buildAssistantReply(
   phase: ConversationPhase,
   userMessage: string,
-  history: Message[]
+  history: Message[],
+  persona?: PersonaManifest
 ) {
+  const activePersona = persona ?? MENTORIA_CARREIRA_PERSONA
+  const extraPatterns = activePersona.structuredOutputExtraPatterns
+  const anchorQuestions = activePersona.anchorQuestions
+
   if (phase === 'PHASE_1_DIAGNOSTICO') {
     const userCount = countUserMessages(history)
-    const nextIndex = Math.min(
-      userCount,
-      PHASE1_ANCHOR_QUESTIONS.length - 1
-    )
+    const nextIndex = Math.min(userCount, anchorQuestions.length - 1)
 
-    if (userCount < PHASE1_ANCHOR_QUESTIONS.length) {
-      return PHASE1_ANCHOR_QUESTIONS[nextIndex]
+    if (userCount < anchorQuestions.length) {
+      return anchorQuestions[nextIndex]
     }
   }
 
@@ -121,7 +120,7 @@ export async function buildAssistantReply(
 
     const response = await chatWithAI({
       phase: 'pdi_chat',
-      systemPrompt: buildPdiChatSystemPrompt(phase),
+      systemPrompt: buildPdiChatSystemPrompt(phase, activePersona),
       messages: aiMessages,
     })
 
@@ -131,7 +130,7 @@ export async function buildAssistantReply(
     }
 
     if (phase === 'PHASE_2_ADAPTATIVO') {
-      return normalizePhase2SingleQuestion(text)
+      return normalizePhase2SingleQuestion(text, extraPatterns)
     }
 
     return text

--- a/src/lib/pdi/page-data.ts
+++ b/src/lib/pdi/page-data.ts
@@ -1,0 +1,49 @@
+import { prisma } from '@/lib/db/prisma'
+import { getOrCreateUserByClerkId, requireClerkUserId } from '@/lib/auth/session'
+import { ensurePdiForUser } from '@/lib/pdi/access'
+import { getPersonaById } from '@/lib/pdi/personas'
+
+export async function getPdiPageData(pdiId: string) {
+  const clerkId = await requireClerkUserId()
+  const user = await getOrCreateUserByClerkId(clerkId)
+
+  const pdi = await ensurePdiForUser(pdiId, user.id)
+
+  const [latestDocument, latestRevision, conversations] = await Promise.all([
+    prisma.pdiDocument.findFirst({
+      where: { projectId: pdi.id },
+      orderBy: { version: 'desc' },
+    }),
+    prisma.pdiRevision.findFirst({
+      where: { projectId: pdi.id },
+      orderBy: { createdAt: 'desc' },
+    }),
+    prisma.conversation.findMany({
+      where: { projectId: pdi.id },
+      include: {
+        messages: {
+          orderBy: { createdAt: 'asc' },
+        },
+      },
+    }),
+  ])
+
+  const sections = latestDocument
+    ? await prisma.pdiDocumentSection.findMany({
+        where: { documentId: latestDocument.id },
+        orderBy: { sectionKey: 'asc' },
+      })
+    : []
+
+  const persona = getPersonaById(pdi.personaId)
+
+  return {
+    user,
+    pdi,
+    persona,
+    latestDocument,
+    sections,
+    latestRevision,
+    conversations,
+  }
+}

--- a/src/lib/pdi/personas.ts
+++ b/src/lib/pdi/personas.ts
@@ -1,0 +1,217 @@
+import type { ConversationPhase } from '@prisma/client'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tipos
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type PersonaId = 'mentoria-carreira' | 'pdi-expresso'
+
+export interface PhaseUiConfig {
+  sidebarLabel: string
+  advanceLabel?: string
+}
+
+export interface PersonaManifest {
+  // Camada 1 — Identidade
+  id: PersonaId
+  displayName: string
+  shortDescription: string
+  estimatedTime: string
+  assistantName: string
+  chatTitle: string
+
+  // Camada 2 — Fluxo
+  skipsPhase2: boolean
+  phases: Partial<Record<ConversationPhase, PhaseUiConfig>>
+
+  // Camada 3 — Prompts de entrada (Fase 1)
+  anchorQuestions: readonly string[]
+  phase2GateQuestion: string | null // null = skip Phase 2
+
+  // Camada 3 — Overrides de system prompt por fase
+  systemPromptOverrides: Partial<Record<ConversationPhase, string>>
+
+  // Camada 4 — Padrões de detecção extras para structured output
+  structuredOutputExtraPatterns: RegExp[]
+
+  // Camada 5 — Labels de UI específicos da persona
+  ctaLabels: {
+    phase1Advance: string
+    phase3Confirm: string
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Persona 1 — Mentoria de Carreira (comportamento atual)
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const MENTORIA_CARREIRA_PERSONA: PersonaManifest = {
+  id: 'mentoria-carreira',
+  displayName: 'Mentoria de Carreira',
+  shortDescription:
+    'Diagnóstico adaptativo profundo com classificação de ramo, triangulação de mercado e hipótese de direção personalizada.',
+  estimatedTime: '~45 min',
+  assistantName: 'Mentor Executivo',
+  chatTitle: 'Mentoria de Carreira',
+
+  skipsPhase2: false,
+
+  phases: {
+    PHASE_1_DIAGNOSTICO: { sidebarLabel: 'Diagnóstico Âncora', advanceLabel: 'Avançar para o Diagnóstico Adaptativo →' },
+    PHASE_2_ADAPTATIVO: { sidebarLabel: 'Diagnóstico Adaptativo', advanceLabel: 'Avançar para a Hipótese de Direção →' },
+    PHASE_3_DIRECAO: { sidebarLabel: 'Hipótese de Direção', advanceLabel: 'Confirmar direção e gerar PDI completo →' },
+    PHASE_5_FINAL: { sidebarLabel: 'Entregáveis Finais' },
+    PHASE_REVISAO: { sidebarLabel: 'Revisão' },
+  },
+
+  anchorQuestions: [
+    '1. Onde você está hoje? (cargo, senioridade, empresa/setor, regime de trabalho)',
+    '2. Qual resultado concreto você quer em 12 meses? (cargo, impacto e faixa salarial)',
+    '3. Na sua visão, qual é o maior obstáculo entre o estado atual e o objetivo?',
+    '4. Qual sua formação acadêmica atual? (curso, nível e status)',
+  ],
+
+  phase2GateQuestion:
+    'Agora vou aprofundar o diagnóstico. Me conta: no seu dia a dia, como esse obstáculo aparece concretamente? Pode ser uma situação recente, um padrão que se repete ou uma tensão que você sente com frequência.',
+
+  systemPromptOverrides: {},
+
+  structuredOutputExtraPatterns: [],
+
+  ctaLabels: {
+    phase1Advance: 'Avançar para o Diagnóstico Adaptativo →',
+    phase3Confirm: 'Confirmar direção e gerar PDI completo →',
+  },
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Persona 2 — PDI Expresso
+// ─────────────────────────────────────────────────────────────────────────────
+
+const PDI_EXPRESSO_BASE_PROMPT = `Você é um especialista operacional em PDI (Plano de Desenvolvimento Individual).
+Responda sempre em português do Brasil.
+Não use contexto fora desta sessão.
+Nunca invente dados ausentes; marque como pendência e pergunte.
+No máximo 4 perguntas por mensagem.
+Seja direto, objetivo e com tom técnico-profissional.
+Não ofereça coaching, orientação de carreira ou reflexões filosóficas.
+Foque em execução: planos concretos, prazos reais, recursos tangíveis.
+Quando relevante, pesquise certificações e trilhas de mercado BR para sugerir caminhos reais.`
+
+const PDI_EXPRESSO_PHASE1_PROMPT = `${PDI_EXPRESSO_BASE_PROMPT}
+
+Fase 1 — Coleta Operacional.
+Objetivo: capturar os 6 dados práticos necessários para montar o PDI.
+As 6 perguntas âncora são conduzidas fora deste prompt, uma a uma.
+Com os 6 dados respondidos, devolva:
+1) "obstáculo principal identificado" em uma frase direta
+2) uma linha de validação breve
+3) "Posso avançar para a proposta de PDI?"`
+
+const PDI_EXPRESSO_PHASE3_PROMPT = `${PDI_EXPRESSO_BASE_PROMPT}
+
+Fase 3 — Proposta de PDI Expresso.
+Com base nos dados coletados, pesquise o mercado brasileiro e proponha um PDI operacional.
+Use EXATAMENTE estes cabeçalhos Markdown (sem alterar o texto dos títulos):
+
+## Síntese do Diagnóstico
+[2-3 frases diretas: cargo atual, objetivo, obstáculo principal]
+
+## Caminhos Possíveis
+
+### Caminho 1 — [nome curto e operacional]
+[descrição com foco em ações concretas]
+- **Certificações/trilhas sugeridas:** [pesquise opções reais do mercado BR]
+- **Custo estimado:** [R$ ou faixas]
+- **Tempo estimado:** [horas/semanas]
+- **Prós:** [lista]
+- **Contras:** [lista]
+
+### Caminho 2 — [nome curto] (se aplicável)
+[mesma estrutura]
+
+### Caminho 3 — [nome curto] (se aplicável)
+[mesma estrutura]
+
+## Recomendação
+[caminho recomendado, justificativa baseada nos recursos disponíveis do usuário (tempo, budget, ferramentas)]
+
+Finalize com uma pergunta direta: qual caminho o usuário quer seguir?`
+
+const PDI_EXPRESSO_PHASE5_PROMPT = `${PDI_EXPRESSO_BASE_PROMPT}
+
+Fase 5 — Entregáveis do PDI Expresso.
+Ajuste checklist 7 dias, plano de estudo semanal, alinhamento gestor-funcionário e resumo executivo.
+Seja específico: horas por semana, plataformas concretas, marcos mensuráveis.`
+
+const PDI_EXPRESSO_REVISAO_PROMPT = `${PDI_EXPRESSO_BASE_PROMPT}
+
+Revisão — Ajustes no PDI.
+Receba pedido de alteração e proponha ajustes consistentes entre seções.
+Explique impactos operacionais das mudanças (prazo, custo, esforço).`
+
+export const PDI_EXPRESSO_PERSONA: PersonaManifest = {
+  id: 'pdi-expresso',
+  displayName: 'PDI Expresso',
+  shortDescription:
+    'Plano direto ao ponto. 6 perguntas práticas, pesquisa de mercado automática e PDI pronto com certificações reais.',
+  estimatedTime: '~15 min',
+  assistantName: 'Especialista PDI',
+  chatTitle: 'PDI Expresso',
+
+  skipsPhase2: true,
+
+  phases: {
+    PHASE_1_DIAGNOSTICO: { sidebarLabel: 'Coleta Operacional', advanceLabel: 'Avançar para a Proposta de PDI →' },
+    PHASE_3_DIRECAO: { sidebarLabel: 'Proposta de PDI', advanceLabel: 'Confirmar e gerar PDI completo →' },
+    PHASE_5_FINAL: { sidebarLabel: 'Entregáveis Finais' },
+    PHASE_REVISAO: { sidebarLabel: 'Revisão' },
+  },
+
+  anchorQuestions: [
+    '1. Qual é seu cargo atual, senioridade e setor? (ex: Analista de Dados Pleno, Fintech)',
+    '2. Qual é seu objetivo profissional em 12 meses? (cargo, responsabilidades, faixa salarial)',
+    '3. Qual é o maior obstáculo técnico ou profissional que está te impedindo agora?',
+    '4. Quantas horas por semana você pode dedicar ao seu desenvolvimento? (ex: 5h/semana)',
+    '5. Qual é seu budget disponível para cursos, certificações ou ferramentas? (ex: R$ 200/mês ou zero)',
+    '6. Quais ferramentas, plataformas ou tecnologias você já usa no trabalho?',
+  ],
+
+  phase2GateQuestion: null, // PDI Expresso não tem Phase 2
+
+  systemPromptOverrides: {
+    PHASE_1_DIAGNOSTICO: PDI_EXPRESSO_PHASE1_PROMPT,
+    PHASE_3_DIRECAO: PDI_EXPRESSO_PHASE3_PROMPT,
+    PHASE_5_FINAL: PDI_EXPRESSO_PHASE5_PROMPT,
+    PHASE_REVISAO: PDI_EXPRESSO_REVISAO_PROMPT,
+  },
+
+  structuredOutputExtraPatterns: [
+    /##\s+proposta\s+de\s+pdi/i,
+    /##\s+coleta\s+operacional/i,
+    /certificaç[õo]es\/trilhas\s+sugeridas/i,
+  ],
+
+  ctaLabels: {
+    phase1Advance: 'Avançar para a Proposta de PDI →',
+    phase3Confirm: 'Confirmar e gerar PDI completo →',
+  },
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Registry e helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const PERSONA_REGISTRY: Record<PersonaId, PersonaManifest> = {
+  'mentoria-carreira': MENTORIA_CARREIRA_PERSONA,
+  'pdi-expresso': PDI_EXPRESSO_PERSONA,
+}
+
+export const ALL_PERSONAS: PersonaManifest[] = [
+  MENTORIA_CARREIRA_PERSONA,
+  PDI_EXPRESSO_PERSONA,
+]
+
+export function getPersonaById(id: string): PersonaManifest {
+  return PERSONA_REGISTRY[id as PersonaId] ?? MENTORIA_CARREIRA_PERSONA
+}

--- a/src/lib/pdi/prompts.ts
+++ b/src/lib/pdi/prompts.ts
@@ -62,9 +62,12 @@ export function buildPdiChatSystemPrompt(
   phase: ConversationPhase,
   persona?: PersonaManifest
 ): string {
-  // Persona override tem prioridade; senão usa prompt padrão
-  const phasePrompt = persona?.systemPromptOverrides?.[phase] ?? PHASE_PROMPTS[phase]
-  return `${BASE_CHAT_PROMPT}\n\n${phasePrompt}`
+  // Persona override define identidade própria — não adicionar BASE_CHAT_PROMPT
+  // para evitar conflito de identidade no system prompt (ex: "mentor executivo sênior"
+  // vs "especialista operacional em PDI" do PDI Expresso).
+  const override = persona?.systemPromptOverrides?.[phase]
+  if (override) return override
+  return `${BASE_CHAT_PROMPT}\n\n${PHASE_PROMPTS[phase]}`
 }
 
 const SECTION_GUIDANCE: Record<PdiSectionKey, string> = {

--- a/src/lib/pdi/prompts.ts
+++ b/src/lib/pdi/prompts.ts
@@ -1,5 +1,6 @@
 import type { ConversationPhase } from '@prisma/client'
 import type { PdiSectionKey, PdiSectionsMap } from './orchestrator'
+import type { PersonaManifest } from './personas'
 
 const BASE_CHAT_PROMPT = `Você é um mentor executivo sênior de carreira.
 Responda sempre em português do Brasil.
@@ -57,8 +58,13 @@ Receba pedido de alteração e proponha ajustes consistentes entre seções.
 Explique brevemente impactos das mudanças.`,
 }
 
-export function buildPdiChatSystemPrompt(phase: ConversationPhase): string {
-  return `${BASE_CHAT_PROMPT}\n\n${PHASE_PROMPTS[phase]}`
+export function buildPdiChatSystemPrompt(
+  phase: ConversationPhase,
+  persona?: PersonaManifest
+): string {
+  // Persona override tem prioridade; senão usa prompt padrão
+  const phasePrompt = persona?.systemPromptOverrides?.[phase] ?? PHASE_PROMPTS[phase]
+  return `${BASE_CHAT_PROMPT}\n\n${phasePrompt}`
 }
 
 const SECTION_GUIDANCE: Record<PdiSectionKey, string> = {

--- a/src/lib/pdi/structured-output.ts
+++ b/src/lib/pdi/structured-output.ts
@@ -1,34 +1,45 @@
 const MARKDOWN_TABLE_DIVIDER = /\n\|[-:\s|]+\|/
 const MARKDOWN_ROW = /\|[^|\n]+\|[^|\n]+\|/
 
-export function isStructuredPhaseOutput(content: string): boolean {
+const BASE_EXECUTIVE_MARKERS: RegExp[] = [
+  /\*\*fase\s*\d+/i,
+  /\*\*eixo\s*\d+/i,
+  /\*\*pend[êe]ncias/i,
+  /\bobst[áa]culo principal identificado\b/i,
+  /(^|\n)\s*(\*\*)?valida[çc][ãa]o\s*:/i,
+  /\b3a\./i,
+  /\b3b\./i,
+  /\b3c\./i,
+  /\bchecklist operacional\b/i,
+  /\bone-pager executivo\b/i,
+  /\balinhamento gestor-funcion[áa]rio\b/i,
+  /✅\s*confirmado/i,
+  /diagn[oó]stico adaptativo conclu[íi]do/i,
+  /\bproposta\s+de\s+dire[çc][ãa]o\b/i,
+  /\bhip[oó]tese\s+de\s+dire[çc][ãa]o\b/i,
+  /##\s+s[íi]ntese\s+do\s+diagn[oó]stico/i,
+  /##\s+caminhos?\s+poss[íi]veis?/i,
+  /##\s+recomenda[çc][ãa]o/i,
+  /###\s+caminho\s+[1-3abc]\b/i,
+  /\*\*\s*caminho\s+[1-3abc]\b/i,
+]
+
+/**
+ * Verifica se o conteúdo é um output estruturado de fase (deve ir para o workspace,
+ * não aparecer no chat). Aceita padrões extras provenientes da persona ativa.
+ */
+export function isStructuredPhaseOutput(
+  content: string,
+  extraPatterns: RegExp[] = []
+): boolean {
   const text = content.trim()
   if (!text) return false
 
   const hasMarkdownTable =
     MARKDOWN_ROW.test(text) && MARKDOWN_TABLE_DIVIDER.test(text)
 
-  const hasExecutiveMarkers =
-    /\*\*fase\s*\d+/i.test(text) ||
-    /\*\*eixo\s*\d+/i.test(text) ||
-    /\*\*pend[êe]ncias/i.test(text) ||
-    /\bobst[áa]culo principal identificado\b/i.test(text) ||
-    /(^|\n)\s*(\*\*)?valida[çc][ãa]o\s*:/i.test(text) ||
-    /\b3a\./i.test(text) ||
-    /\b3b\./i.test(text) ||
-    /\b3c\./i.test(text) ||
-    /\bchecklist operacional\b/i.test(text) ||
-    /\bone-pager executivo\b/i.test(text) ||
-    /\balinhamento gestor-funcion[áa]rio\b/i.test(text) ||
-    /✅\s*confirmado/i.test(text) ||
-    /diagn[oó]stico adaptativo conclu[íi]do/i.test(text) ||
-    /\bproposta\s+de\s+dire[çc][ãa]o\b/i.test(text) ||
-    /\bhip[oó]tese\s+de\s+dire[çc][ãa]o\b/i.test(text) ||
-    /##\s+s[íi]ntese\s+do\s+diagn[oó]stico/i.test(text) ||
-    /##\s+caminhos?\s+poss[íi]veis?/i.test(text) ||
-    /##\s+recomenda[çc][ãa]o/i.test(text) ||
-    /###\s+caminho\s+[1-3abc]\b/i.test(text) ||
-    /\*\*\s*caminho\s+[1-3abc]\b/i.test(text)
+  const allPatterns = [...BASE_EXECUTIVE_MARKERS, ...extraPatterns]
+  const hasExecutiveMarkers = allPatterns.some((pattern) => pattern.test(text))
 
   return hasMarkdownTable || hasExecutiveMarkers
 }


### PR DESCRIPTION
## Summary

- **Nova abstração de persona**: manifests TypeScript estáticos com 5 camadas (identidade, fluxo, prompts, output, UI) em `personas.ts`
- **PDI Expresso**: persona operacional — 6 perguntas práticas, pula a Fase 2 (vai direto Fase 1 → Fase 3), prompts focados em certificações e planos concretos, sem coaching
- **Mentoria de Carreira**: comportamento atual preservado sem mudanças funcionais
- **Tela de seleção**: `/pdi/[id]/escolher-modo` com cards clicáveis antes de iniciar a jornada
- **personaId no DB**: campo `personaId` no `Project` (default: `mentoria-carreira`), endpoint PATCH para salvar escolha

## Arquivos principais

| Arquivo | Mudança |
|---|---|
| `prisma/schema.prisma` | + campo `personaId` |
| `src/lib/pdi/personas.ts` | **NOVO** — manifests das 2 personas |
| `src/lib/pdi/prompts.ts` | aceita persona opcional |
| `src/lib/pdi/structured-output.ts` | aceita extraPatterns da persona |
| `src/lib/pdi/chat-engine.ts` | perguntas âncora e prompts da persona |
| `src/app/api/pdi/[pdiId]/chat/route.ts` | transições persona-aware; PDI Expresso skip Phase 2 |
| `src/app/api/pdi/[pdiId]/persona/route.ts` | **NOVO** — PATCH para salvar persona |
| `src/components/pdi/PdiScreen.tsx` | totalmente persona-aware |
| `src/components/pdi/PhaseChatRail.tsx` | + `assistantName` e `extraStructuredOutputPatterns` props |
| `src/components/pdi/PersonaSelector.tsx` | **NOVO** — client component de seleção |
| `src/app/pdi/[pdiId]/escolher-modo/page.tsx` | **NOVO** — tela de seleção |

## Test plan

- [ ] Login → redireciona para `/escolher-modo`
- [ ] Selecionar **PDI Expresso** → header do chat mostra "PDI Expresso", assistente "Especialista PDI"
- [ ] PDI Expresso: 6 perguntas âncora operacionais (cargo, objetivo, obstáculo, horas, budget, ferramentas)
- [ ] PDI Expresso: após confirmação na Fase 1, vai direto para Fase 3 (sem Fase 2 na sidebar)
- [ ] PDI Expresso: sidebar mostra "Coleta Operacional" e "Proposta de PDI"
- [ ] Selecionar **Mentoria de Carreira** → comportamento atual preservado (4 perguntas âncora, Fase 2 presente)
- [ ] Mentor ativo = "Mentor Executivo" na persona Mentoria de Carreira

🤖 Generated with [Claude Code](https://claude.com/claude-code)